### PR TITLE
Automate release for main branch builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,3 +46,29 @@ jobs:
         with:
           name: qr_gui-macos
           path: dist/qr_gui
+
+  release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build-windows, build-macos]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: qr_gui-windows
+          path: .
+          merge-multiple: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: qr_gui-macos
+          path: .
+          merge-multiple: true
+      - name: Create or update release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: latest
+          name: Latest
+          allowUpdates: true
+          replacesArtifacts: true
+          artifacts: |
+            dist/qr_gui.exe
+            dist/qr_gui

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ core logic and a small CLI.
 
 A GitHub Actions workflow builds standalone executables for Windows and macOS
 using [PyInstaller](https://pyinstaller.org/). Each build runs on its native OS
-and uploads the resulting binary as an artifact.
+and uploads the resulting binary as an artifact. Pushes to the `main` branch
+also update the `Latest` release so the most recent binaries are easily
+available from the Releases page.
 
 You can also build locally:
 


### PR DESCRIPTION
## Summary
- push to `main` now publishes executables as `Latest` release
- document auto-release behavior in README

## Testing
- `python -m py_compile qr_generator.py qr_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6864c78da74c83238c76e1f2f51556b0